### PR TITLE
로그인, 회원가입 화면을 구현하여 앱 초기화면으로 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 lib/firebase_options.dart
 android/app/google-services.json
+lib/app/google-services.json

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,23 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+// import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:muse_mate/app/main_app.dart';
+// import 'package:muse_mate/app/main_app.dart';
+import 'package:muse_mate/screen/login_screen.dart';
 import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  await signInAnonymously();
-  runApp(const MainApp());
+  // await signInAnonymously();
+  runApp(const MyApp());
 }
 
-Future<User?> signInAnonymously() async {
-  try {
-    UserCredential userCredential = await FirebaseAuth.instance
-        .signInAnonymously();
-    return userCredential.user;
-  } catch (e) {
-    print('Error signing in anonymously: $e');
-    return null;
-  }
-}
+// Future<User?> signInAnonymously() async {
+//   try {
+//     UserCredential userCredential = await FirebaseAuth.instance
+//         .signInAnonymously();
+//     return userCredential.user;
+//   } catch (e) {
+//     print('Error signing in anonymously: $e');
+//     return null;
+//   }
+// }

--- a/lib/screen/login_screen.dart
+++ b/lib/screen/login_screen.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:muse_mate/app/main_app.dart';
+
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: LoginScreen(),
+    );
+  }
+}
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 300,
+              child: TextField(controller: _emailController, decoration: const InputDecoration(labelText: '이메일'))),
+            SizedBox(
+              width: 300,
+              child: TextField(controller: _passwordController, decoration: const InputDecoration(labelText: '비밀번호'), obscureText: true)),
+            SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {signIn();},
+              child: const Text('로그인'),
+            ),
+            SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text("아직 회원이 아니신가요?"),
+                SizedBox(width: 10),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => SignUpScreen()),
+                    );
+                  },
+                  child: const Text('회원가입'),
+                ),
+              ],
+            ),
+          ]
+        ),
+      ),
+    );
+  }
+
+   Future<void> signIn() async {
+    try {
+      final userCredential = await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: _emailController.text.trim(),
+        password: _passwordController.text,
+      );
+      // 이메일 인증 여부 체크
+      if (userCredential.user?.emailVerified ?? false) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('로그인 성공!')),
+        );
+        Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (context) => MainApp()),
+                    );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('이메일 인증을 완료해주세요.')),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('로그인 에러: $e')),
+      );
+    }
+  }
+}
+
+
+class SignUpScreen extends StatefulWidget {
+  const SignUpScreen({super.key});
+
+  @override
+  State<SignUpScreen> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _passwordCheckController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 300,
+              child: TextField(controller: _emailController, decoration: const InputDecoration(labelText: '이메일'))),
+            SizedBox(
+              width: 300,
+              child: TextField(controller: _passwordController, decoration: const InputDecoration(labelText: '비밀번호'), obscureText: true)),
+              SizedBox(
+              width: 300,
+              child: TextField(controller: _passwordCheckController, decoration: const InputDecoration(labelText: '비밀번호 확인'), obscureText: true)),
+            SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {signUp();},
+              child: const Text('회원가입'),
+            ),
+            SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {Navigator.pop(context);},
+              child: const Text('돌아가기'),
+            ),
+          ]
+        ),
+      ),
+    );
+  }
+
+  Future<void> signUp() async {
+    if (_passwordController.text != _passwordCheckController.text) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('비밀번호가 일치하지 않습니다.')),
+      );
+      return;
+    }
+    try {
+      final userCredential = await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: _emailController.text.trim(),
+        password: _passwordController.text,
+      );
+      await userCredential.user?.sendEmailVerification();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('회원가입 성공! 이메일 인증을 완료해주세요.')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('회원가입 에러: $e')),
+      );
+    }
+  }
+}


### PR DESCRIPTION
- main.dart에서 로그인 화면인 login_screen.dart의 MyApp을 호출하고, 로그인 성공시 main_app.dart의 MainApp을 호출하도록 수정.
- main.dart의 익명 로그인 방식은 주석처리해둠
- firebase authentication의 이메일/비밀번호 인증 방식 사용
- 로그인, 회원가입을 위해 이메일 주소 형식이 아이디로 사용되며, 회원가입이 완료되는 즉시 이메일 인증을 위한 메일이 발송된다.
이메일 인증을 완료해야 해당 계정으로 로그인이 가능하도록 구현함.
- 로그인에 성공하면 메인 화면으로 넘어간다.
<img width="1504" height="1934" alt="로그인 화면" src="https://github.com/user-attachments/assets/a9e0fa20-bfee-46e0-b925-427d34c11954" />
<img width="1490" height="1938" alt="회원가입 화면" src="https://github.com/user-attachments/assets/25ec5efb-f5b8-4df7-8b9f-840a59701dcb" />

