### PR TITLE
모바일에서 채팅방 메시지 입력 부분 안보임 해결. 라이브 방 싱크 맞추기 버튼 추가

### DIFF
--- a/lib/screen/streaming/live_streaming_room_screen.dart
+++ b/lib/screen/streaming/live_streaming_room_screen.dart
@@ -62,7 +62,7 @@ class _LiveStreamingRoomScreenState extends State<LiveStreamingRoomScreen> {
           endDrawer: SizedBox(
             width: MediaQuery.of(context).size.width * 0.8,
             child: Drawer(
-              child: MessageScreen(roomRef: widget.roomRef),
+              child: SafeArea(child: MessageScreen(roomRef: widget.roomRef)),
             ),
           ),
           body: Stack(

--- a/lib/screen/streaming/streaming_music_screen.dart
+++ b/lib/screen/streaming/streaming_music_screen.dart
@@ -12,10 +12,7 @@ import 'package:muse_mate/screen/streaming/my_playlist.dart';
 
 // YouTube 음악 재생 및 재생목록 관리를 위한 메인 화면.
 class StreamingMusicScreen extends StatefulWidget {
-  const StreamingMusicScreen({
-    super.key,
-    required this.roomRef,
-  });
+  const StreamingMusicScreen({super.key, required this.roomRef});
 
   final dynamic roomRef;
 
@@ -28,7 +25,6 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
   VideoModel? _currentVideo;
   final chatroomRepo = ChatroomRepository();
 
-
   // 초기 동영상을 로드.
   loadVideo() async {
     _currentVideo = await chatroomRepo.getNowPlayingVideo(widget.roomRef);
@@ -36,8 +32,10 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
       setState(() {}); // 로딩 인디케이터 표시용
       return;
     }
-    
-    final elapsedSeconds = await chatroomRepo.getElapsedSecondsSinceLastTrack(widget.roomRef);
+
+    final elapsedSeconds = await chatroomRepo.getElapsedSecondsSinceLastTrack(
+      widget.roomRef,
+    );
 
     if (_currentVideo?.videoId != '') {
       _controller.loadVideoById(
@@ -45,9 +43,8 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
         startSeconds: elapsedSeconds,
       );
     }
-    setState((){});
+    setState(() {});
   }
-
 
   @override
   void initState() {
@@ -83,12 +80,11 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
       _currentVideo,
       widget.roomRef,
     );
-    setState((){}); // playlist에 현재 곡 반영하기 위해.
+    setState(() {}); // playlist에 현재 곡 반영하기 위해.
 
     if (_currentVideo != null) {
       _controller.loadVideoById(videoId: _currentVideo!.videoId);
-    } 
-    else {
+    } else {
       _controller.pauseVideo();
     }
   }
@@ -101,21 +97,20 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
     if (playlistCount == 1) {
       _currentVideo = await chatroomRepo.getNowPlayingVideo(widget.roomRef);
       _controller.loadVideoById(videoId: _currentVideo!.videoId);
-      setState((){});
+      setState(() {});
     }
   }
-
 
   // 재생목록에서 동영상을 제거함.
   void _removeVideo(int index, VideoModel video) async {
     if (video.videoRef == _currentVideo?.videoRef) {
       _moveToNextVideo();
-      setState((){});
+      setState(() {});
       return;
     }
 
     await chatroomRepo.deleteFromPlaylist(video, index, widget.roomRef);
-    setState((){});
+    setState(() {});
   }
 
   @override
@@ -138,7 +133,9 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
                 padding: const EdgeInsets.all(8.0),
                 child: SearchYoutubeScreen(
                   onVideoTap: (id, title) {
-                    _onVideoSelected(VideoModel(videoId: id, title: title, videoRef: ''));
+                    _onVideoSelected(
+                      VideoModel(videoId: id, title: title, videoRef: ''),
+                    );
                     Navigator.of(context).pop(); // 검색 후 drawer 닫기
                   },
                 ),
@@ -156,53 +153,39 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
             title: const Text('Youtube Player IFrame Demo'),
             actions: const [VideoPlaylistIconButton()],
           ),
-          body: LayoutBuilder(
-            builder: (context, constraints) {
-              if (constraints.maxWidth > 750) {
-                return Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+          body: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                customPlayer,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
-                    Expanded(
-                      flex: 3,
-                      child: SingleChildScrollView(
-                        child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              customPlayer,
-                              const Controls(),
-                              // if (_currentVideo != null)
-                                MyPlayList(
-                                  roomRef: widget.roomRef,
-                                  currentVideo: _currentVideo,
-                                  onRemove: _removeVideo,
-                                ),
-                            ],
-                          ),
-                        ),
+                    const Controls(),
+                    Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: FloatingActionButton(
+                        mini: true,
+                        onPressed: () {
+                          loadVideo(); // 현재 방의 동영상 싱크 맞추기
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('싱크 맞추기 완료')),
+                          );
+                        },
+                        child: Icon(Icons.refresh),
+                        tooltip: '라이브 방 싱크 맞추기',
                       ),
                     ),
                   ],
-                );
-              }
-              // 모바일 레이아웃
-              return SingleChildScrollView(
-                child: Column(
-                  children: [
-                    customPlayer,
-                    const Controls(),
-                    // if (_currentVideo != null)
-                      MyPlayList(
-                        roomRef: widget.roomRef,
-                        currentVideo: _currentVideo,
-                        onRemove: _removeVideo,
-                      ),
-                    // 검색창은 drawer에서만 띄움
-                  ],
                 ),
-              );
-            },
+                MyPlayList(
+                  roomRef: widget.roomRef,
+                  currentVideo: _currentVideo,
+                  onRemove: _removeVideo,
+                ),
+              ],
+            ),
           ),
           floatingActionButton: Builder(
             builder: (context) => FloatingActionButton(
@@ -227,7 +210,6 @@ class _StreamingMusicScreenState extends State<StreamingMusicScreen> {
 
 // 재생 컨트롤 및 메타데이터를 위한 위젯.
 class Controls extends StatefulWidget {
-  
   const Controls({super.key});
 
   @override
@@ -249,7 +231,6 @@ class _ControlsState extends State<Controls> {
 
 // 앱바에서 재생목록 관련 동작을 위한 아이콘 버튼.
 class VideoPlaylistIconButton extends StatelessWidget {
-  
   const VideoPlaylistIconButton({super.key});
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -296,6 +296,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  foundation:
+    dependency: "direct main"
+    description:
+      name: foundation
+      sha256: "6f1fda07bd2a422145724b0f94ee68fabac95fabff982d5f334fe1a38cbed6a7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.5"
   freezed_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_cache_manager: ^3.3.1
   pointer_interceptor: ^0.10.1
   flutter_dotenv: ^5.2.1
+  foundation: ^0.0.5
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
모바일 채팅 화면에서 입력 부분 안보임 문제 해결 - live_streaming_room_screen.dart에 MessageScreen을 SafeArea로 감쌈

라이브 방에서 싱크 맞추기 버튼 추가 - streaming_music_screen.dart

streaming_music_screen.dart에 모바일, 웹 레이아웃 중복되는 부분 제거

싱크 맞추기 버튼 추가한 화면
<img width="1518" height="1751" alt="image" src="https://github.com/user-attachments/assets/34917d5b-43a0-411f-b447-a66d1ac3cbc8" />
