### PR TITLE
라이브 방 화면 레이아웃 개선

### DIFF
--- a/lib/screen/chat/chatroom_list.dart
+++ b/lib/screen/chat/chatroom_list.dart
@@ -98,60 +98,62 @@ class _ChatroomListState extends State<ChatroomListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        children: [
-          StreamBuilder<QuerySnapshot>(
-            stream: chatroomRepo.getChatroomListSnapshot(),
-            builder: (context, snapshot) {
-              if (!snapshot.hasData) {
-                return Center(child: CircularProgressIndicator());
-              }
-              
-              final chatRoomDocs = snapshot.data!.docs;
-              if (chatRoomDocs.isEmpty) {
-                return Center(child: Text('No chat rooms found.'));
-              }
-
-              return Expanded(
-                child: ListView.builder(
-                  itemCount: chatRoomDocs.length,
-                  itemBuilder: (context, index) {
-                    final chatRoomDoc = chatRoomDocs[index];
-                    final chatRoomData = chatRoomDoc.data() as Map<String, dynamic>;;
-                    chatRoomData['ref'] = chatRoomDoc.reference;
-
-                    return ListTile(
-                      title: Text(chatRoomData['roomName'] ?? '이름없는 방'),
-                      onTap: () async {
-                        final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => LiveStreamingRoomScreen(
-                              roomRef: chatRoomData['ref'],
+      body: SafeArea(
+        child: Column(
+          children: [
+            StreamBuilder<QuerySnapshot>(
+              stream: chatroomRepo.getChatroomListSnapshot(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return Center(child: CircularProgressIndicator());
+                }
+                
+                final chatRoomDocs = snapshot.data!.docs;
+                if (chatRoomDocs.isEmpty) {
+                  return Center(child: Text('No chat rooms found.'));
+                }
+        
+                return Expanded(
+                  child: ListView.builder(
+                    itemCount: chatRoomDocs.length,
+                    itemBuilder: (context, index) {
+                      final chatRoomDoc = chatRoomDocs[index];
+                      final chatRoomData = chatRoomDoc.data() as Map<String, dynamic>;;
+                      chatRoomData['ref'] = chatRoomDoc.reference;
+        
+                      return ListTile(
+                        title: Text(chatRoomData['roomName'] ?? '이름없는 방'),
+                        onTap: () async {
+                          final result = await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => LiveStreamingRoomScreen(
+                                roomRef: chatRoomData['ref'],
+                              ),
                             ),
-                          ),
-                        );
-                        // LiveStreamingRoomScreen에서 pop(context, true) 했을 경우
-                        if (result == true) {
-                          setState(() {});
-                        }
-                      },
-                    );
-                  },
-                ),
-              );
-            },
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8.0),
-            child: ElevatedButton(
-              onPressed: () {
-                createChatRoom();
+                          );
+                          // LiveStreamingRoomScreen에서 pop(context, true) 했을 경우
+                          if (result == true) {
+                            setState(() {});
+                          }
+                        },
+                      );
+                    },
+                  ),
+                );
               },
-              child: Text('방 만들기'),
             ),
-          ),
-        ],
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: ElevatedButton(
+                onPressed: () {
+                  createChatRoom();
+                },
+                child: Text('방 만들기'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screen/streaming/live_streaming_room_screen.dart
+++ b/lib/screen/streaming/live_streaming_room_screen.dart
@@ -47,14 +47,17 @@ class _LiveStreamingRoomScreenState extends State<LiveStreamingRoomScreen> {
         List playlist = roomData['playlist'];
 
         if (playlist.isEmpty && user?.uid != roomData['hostUserId']) {
-          return Scaffold(body: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            spacing: 20,
-            children: [
-              CircularProgressIndicator(),
-              Text("호스트가 노래를 선택하는 중 입니다."),
-            ],
+          return Scaffold(
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                spacing: 20,
+                children: [
+                  CircularProgressIndicator(),
+                  Text("호스트가 노래를 선택하는 중 입니다."),
+                ],
+              ),
           ));
         }
         return  Scaffold(


### PR DESCRIPTION
모바일에서 채팅방 만들기 버튼 안보임 해결
- chatroom_list.dart - Scaffold body 최상위 위젯을 SafeArea 위젯으로 감싸줌. 
채팅방 입장시, "호스트가 노래를 선택 중입니다" 메시지 중앙에 오도록 수정
- live_streaming_room_screen.dart - 해당 위젯을 Center위젯으로 감싸줌